### PR TITLE
Add badges to README & more Cargo.toml metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ description = "OWL 2 implementation with wasm support and turtle parsing"
 authors = ["Field33", "Florian Loers <florianloers@mailbox.org>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/field33/owlish"
+documentation = "https://docs.rs/owlish"
+keywords = ["owl", "rdf", "semantic-web"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # owlish
 
+[<img alt="github" src="https://img.shields.io/badge/github-field33/owlish-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/field33/owlish)
+[<img alt="crates.io" src="https://img.shields.io/crates/v/owlish.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/owlish)
+[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-owlish-66c2a5?style=for-the-badge&labelColor=555555&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K" height="20">](https://docs.rs/owlish)
+[<img alt="npmjs.com" src="https://img.shields.io/npm/v/owlish.svg?style=for-the-badge&color=fc8d62&logo=npm" height="20">](https://www.npmjs.com/package/owlish)
+
 This library provides OWL2 datastructures that allow you to build and work with ontologies.
 
 The OWL2 model is based on functional style syntax. E.g. the function


### PR DESCRIPTION
Added badges and Cargo.toml metadata, to make it easy (/possible) to discover the Github repo from crates.io and vice versa.