### PR TITLE
fix!: Fix error in public type generation

### DIFF
--- a/src/api/wasm.rs
+++ b/src/api/wasm.rs
@@ -208,32 +208,32 @@ export interface IRI {
 export type Value = {
     _type: "string",
     value: string,
-    datatypeIri: string,
+    datatypeIRI: string,
     lang: null,
 } | {
     _type: "raw",
     value: Uint8Array,
-    datatypeIri: string,
+    datatypeIRI: string,
     lang: null,
 } | {
     _type: "dateTime",
     value: string,
-    datatypeIri: string,
+    datatypeIRI: string,
     lang: null,
 } | {
     _type: "langString",
     value: string,
-    datatypeIri: string,
+    datatypeIRI: string,
     lang: string,
 } | {
     _type: "number",
     value: number,
-    datatypeIri: string,
+    datatypeIRI: string,
     lang: null,
 } | {
     _type: "boolean",
     value: boolean,
-    datatypeIri: string,
+    datatypeIRI: string,
     lang: null,
 }
 

--- a/src/owl/classes/constructors/object_exact_cardinality.rs
+++ b/src/owl/classes/constructors/object_exact_cardinality.rs
@@ -5,7 +5,7 @@ pub struct ObjectExactCardinality {
     pub value: u64,
     #[serde(rename = "objectPropertyIRI")]
     pub object_property_iri: ObjectPropertyIRI,
-    pub cls: Option<ClassIRI>,
+    pub class_iri: Option<ClassIRI>,
 }
 
 impl ObjectExactCardinality {
@@ -13,7 +13,7 @@ impl ObjectExactCardinality {
         Self {
             value,
             object_property_iri,
-            cls,
+            class_iri: cls,
         }
     }
 }

--- a/src/owl/properties/annotation.rs
+++ b/src/owl/properties/annotation.rs
@@ -1,11 +1,14 @@
 use crate::owl::LiteralOrIRI;
 
 use super::AnnotationPropertyIRI;
-
+/// Annotations provide metadata to other concepts. They can be assigned to everything.
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Annotation {
+    #[serde(rename = "annotationIRI")]
     pub iri: AnnotationPropertyIRI,
+    #[serde(rename = "value")]
     pub value: LiteralOrIRI,
+    #[serde(rename = "annotations")]
     pub annotations: Vec<Box<Annotation>>,
 }
 

--- a/src/owl/properties/annotation_property.rs
+++ b/src/owl/properties/annotation_property.rs
@@ -26,8 +26,11 @@ impl Display for AnnotationPropertyIRI {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct AnnotationPropertyDomain {
+    #[serde(rename = "annotationIRI")]
     pub iri: AnnotationPropertyIRI,
-    pub cls: ClassIRI,
+    #[serde(rename = "classIRI")]
+    pub class_iri: ClassIRI,
+    #[serde(rename = "annotations")]
     pub annotations: Vec<Annotation>,
 }
 
@@ -35,7 +38,7 @@ impl AnnotationPropertyDomain {
     pub fn new(iri: AnnotationPropertyIRI, cls: ClassIRI, annotations: Vec<Annotation>) -> Self {
         Self {
             iri,
-            cls,
+            class_iri: cls,
             annotations,
         }
     }
@@ -43,8 +46,11 @@ impl AnnotationPropertyDomain {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct AnnotationPropertyRange {
+    #[serde(rename = "annotationIRI")]
     pub iri: AnnotationPropertyIRI,
+    #[serde(rename = "datatypeIRI")]
     pub datatype_iri: DatatypeIRI,
+    #[serde(rename = "annotations")]
     pub annotations: Vec<Annotation>,
 }
 
@@ -76,9 +82,13 @@ impl From<AnnotationPropertyDomain> for Axiom {
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct AnnotationAssertion {
+    #[serde(rename = "annotationIRI")]
     pub iri: AnnotationPropertyIRI,
+    #[serde(rename = "subjectIRI")]
     pub subject: IRI,
+    #[serde(rename = "value")]
     pub value: LiteralOrIRI,
+    #[serde(rename = "annotations")]
     pub annotations: Vec<Annotation>,
 }
 
@@ -115,17 +125,33 @@ mod wasm {
  */
 export type AnnotationAssertion = {
     /**
-     * The IRI of this annoration.
+     * The IRI of this annotation.
      */
-    iri: IRI, 
+    annotationIRI: IRI, 
     /**
      * The subject IRI.
      */
-    subject: IRI, 
+    subjectIRI: IRI, 
     /**
      * The asserted value.
      */
     value: LiteralOrIRI, 
+    annotations: Array<Annotation>
+};
+export type AnnotationAssertionDomain = {
+    /**
+     * The IRI of this annotation.
+     */
+    annotationIRI: IRI, 
+    classIRI: IRI, 
+    annotations: Array<Annotation>
+};
+export type AnnotationAssertionRange = {
+    /**
+     * The IRI of this annotation.
+     */
+    annotationIRI: IRI, 
+    datatypeIRI: IRI, 
     annotations: Array<Annotation>
 };
 "#;
@@ -136,9 +162,9 @@ export type Annotation = {
     /**
      * The annotation IRI.
      */
-    iri: IRI,
+    annotationIRI: IRI,
     /**
-     * The annotated value.
+     * The annotation value.
      */
     value: LiteralOrIRI,
     annotations: Array<Annotation>,


### PR DESCRIPTION
The `Value` type had a type in the field `datatypeIri`. It is now called `datatypeIRI`.

The Annotation(Assertion/Range/Domain) types changed. Their fields are now more expressive.

BREAKING CHANGE: Public API changed