### PR TITLE
Add Node.js usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ owlish provides two APIs:
 2. A conceptional api that concatenates OWL data for relevant types.
    - TBD
 
+## Usage (Node.js)
+
+To initialize the module in a Node.js environment, it is currently recommend to load the WASM module via the `fs` API and
+pass it explicitly to the initialization function.
+
+Example:
+```js
+import path from 'path';
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+// The next two lines are only required if running the Node script as an ESM module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// Load .wasm file from the package
+const owlishWasm = await readFile(path.join(__dirname, "../node_modules/owlish/owlish_bg.wasm"));
+// Initialize module, after executing this line, all functions from `owlish` can be used like normal.
+await owlish(owlishWasm)
+```
+
 ## Dev stuff
 
 Build:


### PR DESCRIPTION
Together with @bdart I played around with some options on how to best initialize the module in a Node.js environment.

While it's not cleanest way (with having to reference a file from the `node_modules` directory) it works without a lot of additional opinionated setup, and is nicely copy-pasteable.

I think the next better option would be to roughly follow the recommendations from https://nickb.dev/blog/recommendations-when-publishing-a-wasm-library/, and list the `owlish_bg.wasm` in the `exports` of the `package.json`, but I didn't get that to work without Typescript complaining about missing typing.s