### PR TITLE
Make annotations on OPAs work

### DIFF
--- a/src/owl/properties/annotation_property.rs
+++ b/src/owl/properties/annotation_property.rs
@@ -86,10 +86,10 @@ impl From<AnnotationPropertyDomain> for Axiom {
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct AnnotationAssertion {
-    #[serde(rename = "annotationIRI")]
-    pub iri: AnnotationPropertyIRI,
     #[serde(rename = "subjectIRI")]
     pub subject: IRI,
+    #[serde(rename = "annotationIRI")]
+    pub iri: AnnotationPropertyIRI,
     #[serde(rename = "value")]
     pub value: LiteralOrIRI,
     #[serde(rename = "annotations")]

--- a/src/parser/collector.rs
+++ b/src/parser/collector.rs
@@ -25,13 +25,13 @@ pub(crate) enum CollectedBlankNode<'a> {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub(crate) enum CollectedAnnotationKey<'a> {
+pub(crate) enum CollectedReificationKey<'a> {
     Bn(RdfBlankNode),
     Iri(Cow<'a, str>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct CollectedAnnotation<'a> {
+pub(crate) struct CollectedReification<'a> {
     pub(crate) subject: Cow<'a, str>,
     pub(crate) predicate: Cow<'a, str>,
     pub(crate) object: Cow<'a, str>,
@@ -43,10 +43,10 @@ pub(crate) struct OntologyCollector<'a> {
     declarations: Vec<Declaration>,
     axioms: Vec<Axiom>,
 
-    // annotations on things
-    annotations: HashMap<CollectedAnnotationKey<'a>, CollectedAnnotation<'a>>,
+    // reified triples
+    reifications: HashMap<CollectedReificationKey<'a>, CollectedReification<'a>>,
     // TODO: we probably don't need both. There may be a conceptional bug
-    annotations_rev: HashMap<CollectedAnnotation<'a>, CollectedAnnotationKey<'a>>,
+    reifications_rev: HashMap<CollectedReification<'a>, CollectedReificationKey<'a>>,
 
     // annotation definitions that were assigned to other things
     // (to handle multiple assertions for one annotation which is assigned to e.g. one data prop assertion)
@@ -165,27 +165,27 @@ impl<'a> OntologyCollector<'a> {
         self.blank_nodes.insert(bn, bnh);
     }
 
-    pub(crate) fn insert_annotation(
+    pub(crate) fn insert_reification(
         &mut self,
-        key: CollectedAnnotationKey<'a>,
-        value: CollectedAnnotation<'a>,
+        key: CollectedReificationKey<'a>,
+        value: CollectedReification<'a>,
     ) {
-        self.annotations.insert(key.clone(), value.clone());
-        self.annotations_rev.insert(value, key);
+        self.reifications.insert(key.clone(), value.clone());
+        self.reifications_rev.insert(value, key);
     }
 
     pub(crate) fn annotation(
         &self,
-        ann: CollectedAnnotationKey<'a>,
-    ) -> Option<&CollectedAnnotation<'a>> {
-        self.annotations.get(&ann)
+        ann: CollectedReificationKey<'a>,
+    ) -> Option<&CollectedReification<'a>> {
+        self.reifications.get(&ann)
     }
 
     pub(crate) fn annotation_on_triple(
         &self,
-        ann: &CollectedAnnotation<'a>,
-    ) -> Option<&CollectedAnnotationKey<'a>> {
-        self.annotations_rev.get(ann)
+        ann: &CollectedReification<'a>,
+    ) -> Option<&CollectedReificationKey<'a>> {
+        self.reifications_rev.get(ann)
     }
 
     pub(crate) fn ontology(self) -> Ontology {

--- a/src/parser/data_props.rs
+++ b/src/parser/data_props.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use super::{
-    collector::{get_iri_var, CollectedAnnotationKey, MatcherHandler, OntologyCollector},
+    collector::{get_iri_var, CollectedReificationKey, MatcherHandler, OntologyCollector},
     matcher::MatcherState,
 };
 
@@ -98,7 +98,7 @@ pub(crate) fn handle_dataprop_on_bn(
     value: Literal,
 ) -> Result<bool, Error> {
     let annotate = o
-        .annotation(CollectedAnnotationKey::Bn(subject_bn))
+        .annotation(CollectedReificationKey::Bn(subject_bn))
         .cloned();
     if annotate.is_none() {
         return Ok(false);

--- a/src/parser/data_props.rs
+++ b/src/parser/data_props.rs
@@ -108,7 +108,7 @@ pub(crate) fn handle_dataprop_on_bn(
     let predicate = annotate.predicate;
     let object = annotate.object;
 
-    if let Some((axiom, _)) = o.get_from_index_mut(&subject, &predicate, &object) {
+    if let Some((axiom, _)) = o.get_from_axiom_index_mut(&subject, &predicate, &object) {
         axiom
             .annotations_mut()
             .push(Annotation::new(predicate_iri.into(), value.into(), vec![]))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -327,7 +327,6 @@ mod tests {
         },
         parser::{ParserOptions, ParserOptionsBuilder},
     };
-    use crate::computation::GetComputations;
 
     #[test]
     fn ontology() {
@@ -1406,7 +1405,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn annotations_on_object_property_assertions() {
         env_logger::try_init().ok();
@@ -1463,7 +1461,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn annotations_on_object_property_assertions_blank_node() {
         env_logger::try_init().ok();
         let turtle = r##"
@@ -1493,7 +1490,7 @@ mod tests {
                 })
                 .build(),
         )
-            .unwrap();
+        .unwrap();
         println!("{:#?}", o);
         assert_eq!(o.declarations().len(), 3);
         assert_eq!(o.axioms().len(), 2);
@@ -1509,11 +1506,13 @@ mod tests {
                 IRI::new("http://field33.com/org/org_evlGiemVNyAUTJ7D/node/fe6fdda1-fc21-4b99-9269-8c19fc6359b8")
                     .unwrap()
                     .into(),
-                vec![Annotation::new(
-                    well_known::owl_annotatedSource().into(),
-                    IRI::new("http://field33.com/org/org_evlGiemVNyAUTJ7D/node/f63c8031-a7d9-40db-ae87-be04c99537c7").unwrap().into(),
-                    vec![]
-                )]
+                vec![
+                     Annotation::new(
+                         IRI::new("http://field33.com/ontologies/core_change_tracking/createdByImport").unwrap().into(),
+                         "GitHub".into(),
+                         vec![]
+                     ),
+                ]
             ))
         );
     }

--- a/src/parser/object_property_assertions.rs
+++ b/src/parser/object_property_assertions.rs
@@ -1,5 +1,5 @@
-use super::collector::CollectedAnnotation;
-use super::collector::CollectedAnnotationKey;
+use super::collector::CollectedReification;
+use super::collector::CollectedReificationKey;
 use super::collector::MatcherHandler;
 use crate::error::Error;
 use crate::get_vars;
@@ -39,8 +39,8 @@ pub(crate) fn push(
                                             || options.is_object_prop(&predicate)
                                         {
                                             let mut annotations = Vec::new();
-                                            if let Some(CollectedAnnotationKey::Iri(iri)) = o
-                                                .annotation_on_triple(&CollectedAnnotation {
+                                            if let Some(CollectedReificationKey::Iri(iri)) = o
+                                                .annotation_on_triple(&CollectedReification {
                                                     subject: subject.as_str().into(),
                                                     predicate: predicate.as_str().into(),
                                                     object: object.as_str().into(),

--- a/src/parser/object_property_assertions.rs
+++ b/src/parser/object_property_assertions.rs
@@ -27,85 +27,86 @@ pub(crate) fn push(
             [+:subject] [*:predicate] [+:object] .
         )?,
         Box::new(|mstate, o, options| {
-            if let Some(vars) = get_vars!(mstate, subject, predicate, object) {
-                if let Ok(predicate) = vars.predicate.clone().try_into() {
-                    let predicate: IRI = predicate;
-                    if let Value::Iri(iri) = vars.subject {
-                        if let Ok(subject) = IRI::new(iri) {
-                            match vars.object {
-                                Value::Iri(iri) => {
-                                    if let Ok(object) = IRI::new(iri) {
-                                        if o.object_property_declaration(&predicate).is_some()
-                                            || options.is_object_prop(&predicate)
-                                        {
-                                            let mut annotations = Vec::new();
-                                            if let Some(CollectedReificationKey::Iri(iri)) = o
-                                                .annotation_on_triple(&CollectedReification {
-                                                    subject: subject.as_str().into(),
-                                                    predicate: predicate.as_str().into(),
-                                                    object: object.as_str().into(),
-                                                })
-                                            {
-                                                if let Ok(iri) = IRI::new(iri) {
-                                                    annotations.push(Annotation {
-                                                        annotations: vec![],
-                                                        iri: well_known::owl_annotatedSource()
-                                                            .into(),
-                                                        value: iri.into(),
-                                                    })
-                                                }
-                                            }
+            let Some(vars) = get_vars!(mstate, subject, predicate, object) else {
+                return Ok(false);
+            };
+            let Value::Iri(iri) = vars.subject else {
+                return Ok(false);
+            };
+            let Ok(subject) = IRI::new(iri) else {
+                return Ok(false);
+            };
+            let Ok(predicate) = vars.predicate.clone().try_into() else {
+                return Ok(false);
+            };
 
-                                            o.push_axiom(
-                                                ObjectPropertyAssertion::new(
-                                                    predicate.into(),
-                                                    subject.into(),
-                                                    object.into(),
-                                                    annotations,
-                                                )
-                                                .into(),
-                                            )
-                                        }
-                                    }
+            match vars.object {
+                Value::Iri(iri) => {
+                    if let Ok(object) = IRI::new(iri) {
+                        if o.object_property_declaration(&predicate).is_some()
+                            || options.is_object_prop(&predicate)
+                        {
+                            let mut annotations = Vec::new();
+                            if let Some(CollectedReificationKey::Iri(iri)) = o
+                                .annotation_on_triple(&CollectedReification {
+                                    subject: subject.as_str().into(),
+                                    predicate: predicate.as_str().into(),
+                                    object: object.as_str().into(),
+                                })
+                            {
+                                if let Ok(iri) = IRI::new(iri) {
+                                    annotations.push(Annotation {
+                                        annotations: vec![],
+                                        iri: well_known::owl_annotatedSource().into(),
+                                        value: iri.into(),
+                                    })
                                 }
-                                Value::Blank(bn) => {
-                                    let mut object = Vec::new();
-                                    let mut b = Some(bn);
-                                    while let Some(bn) = b {
-                                        b = None;
-                                        if let Some(
-                                            super::collector::CollectedBlankNode::Sequence {
-                                                first,
-                                                rest,
-                                            },
-                                        ) = o.get_blank(bn)
-                                        {
-                                            if let Some(Value::Iri(iri)) = first {
-                                                if let Ok(iri) = IRI::new(iri) {
-                                                    object.push(iri);
-                                                    b = rest.as_ref();
-                                                }
-                                            }
-                                        }
-                                    }
-                                    if object.len() > 0 {
-                                        o.push_axiom(
-                                            ObjectPropertyAssertion::new_with_list(
-                                                predicate.into(),
-                                                subject.into(),
-                                                object,
-                                                vec![],
-                                            )
-                                            .into(),
-                                        )
-                                    }
-                                }
-                                _ => {
-                                    //ignore
+                            }
+
+                            o.push_axiom(
+                                ObjectPropertyAssertion::new(
+                                    predicate.into(),
+                                    subject.into(),
+                                    object.into(),
+                                    annotations,
+                                )
+                                .into(),
+                            )
+                        }
+                    }
+                }
+                Value::Blank(bn) => {
+                    let mut object = Vec::new();
+                    let mut b = Some(bn);
+                    while let Some(bn) = b {
+                        b = None;
+                        if let Some(super::collector::CollectedBlankNode::Sequence {
+                            first,
+                            rest,
+                        }) = o.get_blank(bn)
+                        {
+                            if let Some(Value::Iri(iri)) = first {
+                                if let Ok(iri) = IRI::new(iri) {
+                                    object.push(iri);
+                                    b = rest.as_ref();
                                 }
                             }
                         }
                     }
+                    if object.len() > 0 {
+                        o.push_axiom(
+                            ObjectPropertyAssertion::new_with_list(
+                                predicate.into(),
+                                subject.into(),
+                                object,
+                                vec![],
+                            )
+                            .into(),
+                        )
+                    }
+                }
+                Value::Literal { .. } => {
+                    unreachable!("Branch should be unreachable, as matcher shouldn't match literal objects.")
                 }
             }
             Ok(false)


### PR DESCRIPTION
- Renamed some functions and fields that refered to `annotations`, but were actually dealing with reified statements/triples
- Accumulate annotations for axioms that have not been parsed yet in the collector
  - This allows us to pick up annotations for OPAs (which are parsed later than the annotations on them)